### PR TITLE
fix: point package-lock resolved URLs at public npm registry

### DIFF
--- a/ClientApp/package-lock.json
+++ b/ClientApp/package-lock.json
@@ -59,7 +59,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
@@ -73,7 +73,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
@@ -83,7 +83,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/core/-/core-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
@@ -114,14 +114,14 @@
     },
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -131,7 +131,7 @@
     },
     "node_modules/@babel/eslint-parser": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
       "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
       "dev": true,
       "license": "MIT",
@@ -150,7 +150,7 @@
     },
     "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -160,7 +160,7 @@
     },
     "node_modules/@babel/eslint-parser/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -170,7 +170,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/generator/-/generator-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
@@ -186,7 +186,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
       "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "license": "MIT",
@@ -199,7 +199,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
@@ -216,7 +216,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -226,7 +226,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
       "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
@@ -248,7 +248,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -258,7 +258,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
@@ -267,7 +267,7 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
       "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
       "license": "MIT",
@@ -281,7 +281,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
@@ -294,7 +294,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
@@ -312,7 +312,7 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
       "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "dev": true,
       "license": "MIT",
@@ -325,7 +325,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
@@ -335,7 +335,7 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
       "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "dev": true,
       "license": "MIT",
@@ -353,7 +353,7 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
       "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dev": true,
       "license": "MIT",
@@ -367,7 +367,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
@@ -376,7 +376,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
@@ -385,7 +385,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
@@ -395,7 +395,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helpers/-/helpers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
@@ -409,7 +409,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/parser/-/parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
@@ -424,7 +424,7 @@
     },
     "node_modules/@babel/plugin-proposal-decorators": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
       "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
       "dev": true,
       "license": "MIT",
@@ -442,7 +442,7 @@
     },
     "node_modules/@babel/plugin-syntax-decorators": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
       "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
       "dev": true,
       "license": "MIT",
@@ -458,7 +458,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
       "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
@@ -474,7 +474,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
       "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
@@ -490,7 +490,7 @@
     },
     "node_modules/@babel/plugin-transform-class-properties": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
       "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
       "dev": true,
       "license": "MIT",
@@ -507,7 +507,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
       "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "dev": true,
       "license": "MIT",
@@ -524,7 +524,7 @@
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
       "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
       "dev": true,
       "license": "MIT",
@@ -540,7 +540,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
       "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
       "dev": true,
       "license": "MIT",
@@ -560,7 +560,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
       "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
       "dev": true,
       "license": "MIT",
@@ -576,7 +576,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
       "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
@@ -592,7 +592,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
       "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "license": "MIT",
@@ -608,7 +608,7 @@
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
       "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
       "dev": true,
       "license": "MIT",
@@ -625,7 +625,7 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
       "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
       "dev": true,
       "license": "MIT",
@@ -645,7 +645,7 @@
     },
     "node_modules/@babel/preset-react": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/preset-react/-/preset-react-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
       "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
       "dev": true,
       "license": "MIT",
@@ -666,7 +666,7 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
       "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
       "dev": true,
       "license": "MIT",
@@ -686,7 +686,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
@@ -695,7 +695,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/template/-/template-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
@@ -709,7 +709,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/traverse/-/traverse-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
@@ -727,7 +727,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/types/-/types-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
@@ -824,7 +824,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
@@ -841,7 +841,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
       "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
@@ -858,7 +858,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
@@ -875,7 +875,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
@@ -892,7 +892,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
       "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
@@ -909,7 +909,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
@@ -926,7 +926,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
       "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
@@ -943,7 +943,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
@@ -960,7 +960,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
@@ -977,7 +977,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
       "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
@@ -994,7 +994,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
       "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
@@ -1011,7 +1011,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
@@ -1028,7 +1028,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
       "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
@@ -1045,7 +1045,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
@@ -1062,7 +1062,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
       "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
@@ -1079,7 +1079,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
@@ -1096,7 +1096,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
       "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
@@ -1113,7 +1113,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
@@ -1130,7 +1130,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
       "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
@@ -1147,7 +1147,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
@@ -1164,7 +1164,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
       "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
@@ -1181,7 +1181,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
@@ -1198,7 +1198,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
       "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
@@ -1215,7 +1215,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
@@ -1232,7 +1232,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
       "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
@@ -1249,7 +1249,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
@@ -1266,7 +1266,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
@@ -1285,7 +1285,7 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1298,7 +1298,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -1308,7 +1308,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1323,7 +1323,7 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1336,7 +1336,7 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/core/-/core-0.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1349,7 +1349,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
@@ -1373,7 +1373,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/js/-/js-9.39.4.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
@@ -1386,7 +1386,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1396,7 +1396,7 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1547,7 +1547,7 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanfs/core/-/core-0.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1560,7 +1560,7 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanfs/node/-/node-0.16.8.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1575,7 +1575,7 @@
     },
     "node_modules/@humanfs/types": {
       "version": "0.15.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanfs/types/-/types-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1585,7 +1585,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1599,7 +1599,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1613,7 +1613,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
@@ -1623,7 +1623,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
@@ -1634,7 +1634,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
@@ -1643,13 +1643,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
@@ -1664,7 +1664,7 @@
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
       "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
       "dev": true,
       "license": "MIT",
@@ -1674,7 +1674,7 @@
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1688,7 +1688,7 @@
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1698,14 +1698,14 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
       "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
@@ -1719,7 +1719,7 @@
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
       "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
@@ -1733,7 +1733,7 @@
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
       "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
@@ -1747,7 +1747,7 @@
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
       "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
@@ -1761,7 +1761,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
       "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
@@ -1775,7 +1775,7 @@
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
       "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
@@ -1789,7 +1789,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
@@ -1806,7 +1806,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
@@ -1823,7 +1823,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
       "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
@@ -1840,7 +1840,7 @@
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
@@ -1857,7 +1857,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
       "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
@@ -1874,7 +1874,7 @@
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
@@ -1891,7 +1891,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
       "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
@@ -1908,7 +1908,7 @@
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
@@ -1925,7 +1925,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
       "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
@@ -1942,7 +1942,7 @@
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
@@ -1959,7 +1959,7 @@
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
       "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
@@ -1976,7 +1976,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
@@ -1993,7 +1993,7 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
@@ -2010,7 +2010,7 @@
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
       "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
@@ -2024,7 +2024,7 @@
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
       "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
@@ -2038,7 +2038,7 @@
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
       "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
@@ -2052,7 +2052,7 @@
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
       "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
@@ -2066,7 +2066,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
@@ -2080,7 +2080,7 @@
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
       "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
@@ -2094,14 +2094,14 @@
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rtsao/scc/-/scc-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
@@ -2115,7 +2115,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
@@ -2125,7 +2125,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
@@ -2136,7 +2136,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
@@ -2151,7 +2151,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/estree/-/estree-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
@@ -2170,14 +2170,14 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
@@ -2194,7 +2194,7 @@
     },
     "node_modules/@types/react": {
       "version": "16.14.70",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/react/-/react-16.14.70.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.70.tgz",
       "integrity": "sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==",
       "license": "MIT",
       "dependencies": {
@@ -2205,7 +2205,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "16.9.25",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/react-dom/-/react-dom-16.9.25.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
       "integrity": "sha512-ZK//eAPhwft9Ul2/Zj+6O11YR6L4JX0J2sVeBC9Ft7x7HFN7xk7yUV/zDxqV6rjvqgl6r8Dq7oQImxtyf/Mzcw==",
       "license": "MIT",
       "peerDependencies": {
@@ -2255,13 +2255,13 @@
     },
     "node_modules/@types/react/node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
       "license": "MIT"
     },
@@ -2360,7 +2360,7 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
@@ -2381,7 +2381,7 @@
     },
     "node_modules/@vitejs/plugin-react/node_modules/react-refresh": {
       "version": "0.17.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-refresh/-/react-refresh-0.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
       "license": "MIT",
@@ -2391,7 +2391,7 @@
     },
     "node_modules/acorn": {
       "version": "8.17.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/acorn/-/acorn-8.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
@@ -2404,7 +2404,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -2414,7 +2414,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "dependencies": {
@@ -2426,7 +2426,7 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ajv/-/ajv-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
@@ -2443,7 +2443,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -2459,14 +2459,14 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/aria-query/-/aria-query-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2476,7 +2476,7 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
@@ -2493,7 +2493,7 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array-includes/-/array-includes-3.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
       "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
       "license": "MIT",
@@ -2516,7 +2516,7 @@
     },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
@@ -2537,7 +2537,7 @@
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
       "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
@@ -2559,7 +2559,7 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
       "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
@@ -2578,7 +2578,7 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
       "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
@@ -2597,7 +2597,7 @@
     },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
@@ -2614,7 +2614,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
@@ -2636,14 +2636,14 @@
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/async-function/-/async-function-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
       "license": "MIT",
@@ -2653,13 +2653,13 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
@@ -2675,7 +2675,7 @@
     },
     "node_modules/axe-core": {
       "version": "4.12.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/axe-core/-/axe-core-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
       "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
@@ -2685,7 +2685,7 @@
     },
     "node_modules/axios": {
       "version": "1.18.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/axios/-/axios-1.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
@@ -2697,7 +2697,7 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/axobject-query/-/axobject-query-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2749,7 +2749,7 @@
     },
     "node_modules/babel-plugin-macros/node_modules/yaml": {
       "version": "1.10.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/yaml/-/yaml-1.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
@@ -2788,7 +2788,7 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2814,7 +2814,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
@@ -2825,7 +2825,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/browserslist/-/browserslist-4.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
       "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
@@ -2859,7 +2859,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/call-bind/-/call-bind-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
@@ -2878,7 +2878,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -2891,7 +2891,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
@@ -2916,7 +2916,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001803",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
       "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
@@ -2937,7 +2937,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -2959,7 +2959,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -2972,14 +2972,14 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
@@ -3005,7 +3005,7 @@
     },
     "node_modules/core-js": {
       "version": "3.49.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/core-js/-/core-js-3.49.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
       "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -3026,7 +3026,7 @@
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cross-env/-/cross-env-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
       "license": "MIT",
@@ -3045,7 +3045,7 @@
     },
     "node_modules/cross-fetch": {
       "version": "4.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
       "dependencies": {
@@ -3054,7 +3054,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -3069,7 +3069,7 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/crypto-js/-/crypto-js-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
@@ -3080,14 +3080,14 @@
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
@@ -3105,7 +3105,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
@@ -3123,7 +3123,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
@@ -3146,7 +3146,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -3163,20 +3163,20 @@
     },
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
@@ -3194,7 +3194,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
@@ -3212,7 +3212,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "engines": {
@@ -3235,7 +3235,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -3249,7 +3249,7 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.389",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
       "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
@@ -3264,7 +3264,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-abstract/-/es-abstract-1.24.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
       "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
@@ -3333,7 +3333,7 @@
     },
     "node_modules/es-abstract-get": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
       "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
       "dev": true,
       "license": "MIT",
@@ -3352,7 +3352,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -3361,7 +3361,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -3370,7 +3370,7 @@
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
       "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
       "dev": true,
       "license": "MIT",
@@ -3398,7 +3398,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
@@ -3410,7 +3410,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
@@ -3425,7 +3425,7 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
       "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "license": "MIT",
@@ -3438,7 +3438,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
       "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
@@ -3459,7 +3459,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/esbuild/-/esbuild-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
@@ -3501,7 +3501,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -3519,7 +3519,7 @@
     },
     "node_modules/eslint": {
       "version": "9.39.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint/-/eslint-9.39.4.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
@@ -3579,7 +3579,7 @@
     },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
       "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "dev": true,
       "license": "MIT",
@@ -3591,7 +3591,7 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
@@ -3601,14 +3601,14 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint-import-resolver-node/node_modules/resolve": {
       "version": "2.0.0-next.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/resolve/-/resolve-2.0.0-next.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
       "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
@@ -3632,7 +3632,7 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.14.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
       "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
@@ -3650,7 +3650,7 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
@@ -3660,14 +3660,14 @@
     },
     "node_modules/eslint-module-utils/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
@@ -3701,7 +3701,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
@@ -3711,7 +3711,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/doctrine/-/doctrine-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3724,14 +3724,14 @@
     },
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -3741,7 +3741,7 @@
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
@@ -3771,14 +3771,14 @@
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
@@ -3823,7 +3823,7 @@
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/resolve/-/resolve-2.0.0-next.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
       "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
@@ -3847,7 +3847,7 @@
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -3857,7 +3857,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3874,7 +3874,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3887,7 +3887,7 @@
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -3900,7 +3900,7 @@
     },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/find-up/-/find-up-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -3917,7 +3917,7 @@
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/locate-path/-/locate-path-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -3933,7 +3933,7 @@
     },
     "node_modules/eslint/node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -3949,7 +3949,7 @@
     },
     "node_modules/eslint/node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/p-locate/-/p-locate-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -3965,7 +3965,7 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/espree/-/espree-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3983,7 +3983,7 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3996,7 +3996,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4009,7 +4009,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4040,14 +4040,14 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -4065,7 +4065,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -4088,7 +4088,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/flat-cache/-/flat-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -4102,14 +4102,14 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/flatted/-/flatted-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
@@ -4129,7 +4129,7 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/for-each/-/for-each-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
@@ -4145,7 +4145,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/form-data/-/form-data-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
@@ -4161,7 +4161,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -4176,7 +4176,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -4185,7 +4185,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
       "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
@@ -4209,7 +4209,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
       "license": "MIT",
@@ -4219,7 +4219,7 @@
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/generator-function/-/generator-function-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true,
       "license": "MIT",
@@ -4238,7 +4238,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -4262,7 +4262,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -4275,7 +4275,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
@@ -4293,7 +4293,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -4306,7 +4306,7 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/globals/-/globals-14.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
@@ -4319,7 +4319,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
@@ -4336,7 +4336,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -4348,7 +4348,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-bigints/-/has-bigints-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
@@ -4361,7 +4361,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -4371,7 +4371,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
@@ -4384,7 +4384,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-proto/-/has-proto-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
@@ -4400,7 +4400,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -4412,7 +4412,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "dependencies": {
@@ -4427,7 +4427,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -4460,7 +4460,7 @@
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "license": "MIT",
       "dependencies": {
@@ -4469,7 +4469,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "dependencies": {
@@ -4498,7 +4498,7 @@
     },
     "node_modules/i18next-http-backend": {
       "version": "3.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
       "integrity": "sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==",
       "license": "MIT",
       "dependencies": {
@@ -4507,7 +4507,7 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -4529,7 +4529,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -4539,7 +4539,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/internal-slot/-/internal-slot-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
@@ -4554,7 +4554,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
@@ -4577,7 +4577,7 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-async-function/-/is-async-function-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "license": "MIT",
@@ -4597,7 +4597,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-bigint/-/is-bigint-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
@@ -4613,7 +4613,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
@@ -4630,7 +4630,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
@@ -4643,7 +4643,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-core-module/-/is-core-module-2.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
@@ -4658,7 +4658,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-data-view/-/is-data-view-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
@@ -4676,7 +4676,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-date-object/-/is-date-object-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
@@ -4693,7 +4693,7 @@
     },
     "node_modules/is-document.all": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-document.all/-/is-document.all-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
       "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
       "dev": true,
       "license": "MIT",
@@ -4718,7 +4718,7 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
@@ -4734,7 +4734,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
@@ -4754,7 +4754,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -4767,7 +4767,7 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-map/-/is-map-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
@@ -4780,7 +4780,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
@@ -4793,7 +4793,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-number-object/-/is-number-object-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
@@ -4810,7 +4810,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-regex/-/is-regex-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
@@ -4829,7 +4829,7 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-set/-/is-set-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
       "license": "MIT",
@@ -4842,7 +4842,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
@@ -4858,7 +4858,7 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-string/-/is-string-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
@@ -4875,7 +4875,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-symbol/-/is-symbol-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
@@ -4893,7 +4893,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
@@ -4909,7 +4909,7 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
@@ -4922,7 +4922,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-weakref/-/is-weakref-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
@@ -4938,7 +4938,7 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-weakset/-/is-weakset-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
@@ -4960,14 +4960,14 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
@@ -4995,7 +4995,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/js-yaml/-/js-yaml-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
@@ -5018,7 +5018,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
@@ -5030,7 +5030,7 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
@@ -5042,21 +5042,21 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -5069,7 +5069,7 @@
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
@@ -5085,7 +5085,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -5095,14 +5095,14 @@
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
       "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/language-tags/-/language-tags-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "license": "MIT",
@@ -5115,7 +5115,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -5134,7 +5134,7 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
@@ -5150,7 +5150,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
@@ -5173,7 +5173,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
@@ -5183,7 +5183,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -5197,7 +5197,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
@@ -5206,7 +5206,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
@@ -5231,7 +5231,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -5244,7 +5244,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
@@ -5280,7 +5280,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.15",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/nanoid/-/nanoid-3.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
@@ -5298,14 +5298,14 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-exports-info": {
       "version": "1.6.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
       "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
       "dev": true,
       "license": "MIT",
@@ -5324,7 +5324,7 @@
     },
     "node_modules/node-exports-info/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -5334,7 +5334,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
@@ -5354,7 +5354,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.50",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/node-releases/-/node-releases-2.0.50.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
@@ -5372,7 +5372,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
@@ -5394,7 +5394,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.assign/-/object.assign-4.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
@@ -5415,7 +5415,7 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.entries/-/object.entries-1.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
@@ -5431,7 +5431,7 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
       "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "license": "MIT",
@@ -5450,7 +5450,7 @@
     },
     "node_modules/object.groupby": {
       "version": "1.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.groupby/-/object.groupby-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
       "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
       "license": "MIT",
@@ -5465,7 +5465,7 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.values/-/object.values-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
       "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "license": "MIT",
@@ -5510,7 +5510,7 @@
     },
     "node_modules/oidc-client": {
       "version": "1.11.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/oidc-client/-/oidc-client-1.11.5.tgz",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
       "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -5523,7 +5523,7 @@
     },
     "node_modules/oidc-client/node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/acorn/-/acorn-7.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
       "bin": {
@@ -5535,7 +5535,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -5553,7 +5553,7 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/own-keys/-/own-keys-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
@@ -5582,7 +5582,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "dependencies": {
@@ -5600,7 +5600,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -5610,7 +5610,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -5620,13 +5620,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
       "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "license": "MIT",
       "dependencies": {
@@ -5643,13 +5643,13 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
@@ -5672,7 +5672,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
@@ -5682,7 +5682,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.16",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/postcss/-/postcss-8.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
@@ -5711,7 +5711,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -5721,7 +5721,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/prop-types/-/prop-types-15.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
       "dependencies": {
@@ -5732,7 +5732,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
       "engines": {
@@ -5741,7 +5741,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -5764,7 +5764,7 @@
     },
     "node_modules/react-checkbox-tree": {
       "version": "1.8.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-checkbox-tree/-/react-checkbox-tree-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.8.0.tgz",
       "integrity": "sha512-ufC4aorihOvjLpvY1beab2hjVLGZbDTFRzw62foG0+th+KX7e/sdmWu/nD1ZS/U5Yr0rWGwedGH5GOtR0IkUXw==",
       "license": "MIT",
       "dependencies": {
@@ -5793,7 +5793,7 @@
     },
     "node_modules/react-i18next": {
       "version": "11.18.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-i18next/-/react-i18next-11.18.6.tgz",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
       "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
       "license": "MIT",
       "dependencies": {
@@ -5974,7 +5974,7 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
@@ -5997,7 +5997,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
@@ -6018,7 +6018,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/resolve/-/resolve-1.22.12.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
@@ -6052,7 +6052,7 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
       "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
@@ -6072,7 +6072,7 @@
     },
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
@@ -6084,7 +6084,7 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
@@ -6101,14 +6101,14 @@
     },
     "node_modules/safe-push-apply/node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
@@ -6135,7 +6135,7 @@
     },
     "node_modules/serialize-javascript": {
       "version": "7.0.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
       "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -6144,7 +6144,7 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
@@ -6162,7 +6162,7 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-function-name/-/set-function-name-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "license": "MIT",
@@ -6178,7 +6178,7 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-proto/-/set-proto-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "license": "MIT",
@@ -6193,7 +6193,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -6206,7 +6206,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -6216,7 +6216,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
@@ -6236,7 +6236,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
@@ -6253,7 +6253,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
@@ -6272,7 +6272,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
@@ -6300,7 +6300,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6310,7 +6310,7 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
@@ -6324,7 +6324,7 @@
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "license": "MIT",
@@ -6339,7 +6339,7 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
@@ -6367,7 +6367,7 @@
     },
     "node_modules/string.prototype.repeat": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
@@ -6378,7 +6378,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.11",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
       "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
@@ -6401,7 +6401,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.10",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
       "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
@@ -6420,7 +6420,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "license": "MIT",
@@ -6438,7 +6438,7 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
@@ -6448,7 +6448,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
@@ -6461,7 +6461,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -6474,7 +6474,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "engines": {
@@ -6496,7 +6496,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
@@ -6513,13 +6513,13 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "license": "MIT",
@@ -6532,7 +6532,7 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json5/-/json5-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "license": "MIT",
@@ -6550,7 +6550,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -6563,7 +6563,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
@@ -6578,7 +6578,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
@@ -6598,7 +6598,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
@@ -6620,7 +6620,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
       "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
@@ -6654,7 +6654,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
@@ -6673,7 +6673,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -6704,7 +6704,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6719,7 +6719,7 @@
     },
     "node_modules/vite": {
       "version": "6.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/vite/-/vite-6.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
@@ -6794,7 +6794,7 @@
     },
     "node_modules/vite/node_modules/rollup": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/rollup/-/rollup-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
@@ -6839,7 +6839,7 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/void-elements/-/void-elements-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "license": "MIT",
       "engines": {
@@ -6848,13 +6848,13 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "dependencies": {
@@ -6864,7 +6864,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -6880,7 +6880,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
@@ -6900,7 +6900,7 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
@@ -6928,14 +6928,14 @@
     },
     "node_modules/which-builtin-type/node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-collection/-/which-collection-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "license": "MIT",
@@ -6954,7 +6954,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
       "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
@@ -6976,7 +6976,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -6986,14 +6986,14 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -7008,7 +7008,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -7018,13 +7018,13 @@
     },
     "@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true
     },
     "@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/core/-/core-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "requires": {
@@ -7047,13 +7047,13 @@
       "dependencies": {
         "convert-source-map": {
           "version": "2.0.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
           "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
           "dev": true
         },
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -7061,7 +7061,7 @@
     },
     "@babel/eslint-parser": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
       "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
       "dev": true,
       "requires": {
@@ -7072,13 +7072,13 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "2.1.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         },
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -7086,7 +7086,7 @@
     },
     "@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/generator/-/generator-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "requires": {
         "@babel/parser": "^7.29.7",
@@ -7098,7 +7098,7 @@
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
       "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "requires": {
@@ -7107,7 +7107,7 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "requires": {
@@ -7120,7 +7120,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -7128,7 +7128,7 @@
     },
     "@babel/helper-create-class-features-plugin": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
       "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "requires": {
@@ -7143,7 +7143,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -7151,12 +7151,12 @@
     },
     "@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
       "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
       "requires": {
@@ -7166,7 +7166,7 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "requires": {
         "@babel/traverse": "^7.29.7",
@@ -7175,7 +7175,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "requires": {
@@ -7186,7 +7186,7 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
       "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "dev": true,
       "requires": {
@@ -7195,13 +7195,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
       "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "dev": true,
       "requires": {
@@ -7212,7 +7212,7 @@
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
       "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dev": true,
       "requires": {
@@ -7222,23 +7222,23 @@
     },
     "@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="
     },
     "@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true
     },
     "@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/helpers/-/helpers-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "requires": {
@@ -7248,7 +7248,7 @@
     },
     "@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/parser/-/parser-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "requires": {
         "@babel/types": "^7.29.7"
@@ -7256,7 +7256,7 @@
     },
     "@babel/plugin-proposal-decorators": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
       "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
       "dev": true,
       "requires": {
@@ -7267,7 +7267,7 @@
     },
     "@babel/plugin-syntax-decorators": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
       "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
       "dev": true,
       "requires": {
@@ -7276,7 +7276,7 @@
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
       "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "requires": {
@@ -7285,7 +7285,7 @@
     },
     "@babel/plugin-syntax-typescript": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
       "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "requires": {
@@ -7294,7 +7294,7 @@
     },
     "@babel/plugin-transform-class-properties": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
       "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
       "dev": true,
       "requires": {
@@ -7304,7 +7304,7 @@
     },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
       "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "dev": true,
       "requires": {
@@ -7314,7 +7314,7 @@
     },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
       "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
       "dev": true,
       "requires": {
@@ -7323,7 +7323,7 @@
     },
     "@babel/plugin-transform-react-jsx": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
       "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
       "dev": true,
       "requires": {
@@ -7336,7 +7336,7 @@
     },
     "@babel/plugin-transform-react-jsx-development": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
       "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
       "dev": true,
       "requires": {
@@ -7345,7 +7345,7 @@
     },
     "@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
       "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "requires": {
@@ -7354,7 +7354,7 @@
     },
     "@babel/plugin-transform-react-jsx-source": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
       "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "requires": {
@@ -7363,7 +7363,7 @@
     },
     "@babel/plugin-transform-react-pure-annotations": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
       "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
       "dev": true,
       "requires": {
@@ -7373,7 +7373,7 @@
     },
     "@babel/plugin-transform-typescript": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
       "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
       "dev": true,
       "requires": {
@@ -7386,7 +7386,7 @@
     },
     "@babel/preset-react": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/preset-react/-/preset-react-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
       "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
       "dev": true,
       "requires": {
@@ -7400,7 +7400,7 @@
     },
     "@babel/preset-typescript": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
       "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
       "dev": true,
       "requires": {
@@ -7413,12 +7413,12 @@
     },
     "@babel/runtime": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/runtime/-/runtime-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
     },
     "@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/template/-/template-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "requires": {
         "@babel/code-frame": "^7.29.7",
@@ -7428,7 +7428,7 @@
     },
     "@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/traverse/-/traverse-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "requires": {
         "@babel/code-frame": "^7.29.7",
@@ -7442,7 +7442,7 @@
     },
     "@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@babel/types/-/types-7.29.7.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "requires": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -7532,189 +7532,189 @@
     },
     "@esbuild/aix-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
       "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
       "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
       "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
       "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
       "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
       "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
       "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
       "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
       "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
       "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openharmony-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
       "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
       "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "dev": true,
       "optional": true
     },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "requires": {
@@ -7723,7 +7723,7 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "3.4.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
           "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
           "dev": true
         }
@@ -7731,13 +7731,13 @@
     },
     "@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true
     },
     "@eslint/config-array": {
       "version": "0.21.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "requires": {
@@ -7748,7 +7748,7 @@
     },
     "@eslint/config-helpers": {
       "version": "0.4.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "requires": {
@@ -7757,7 +7757,7 @@
     },
     "@eslint/core": {
       "version": "0.17.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/core/-/core-0.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "requires": {
@@ -7766,7 +7766,7 @@
     },
     "@eslint/eslintrc": {
       "version": "3.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "requires": {
@@ -7783,19 +7783,19 @@
     },
     "@eslint/js": {
       "version": "9.39.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/js/-/js-9.39.4.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true
     },
     "@eslint/object-schema": {
       "version": "2.1.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true
     },
     "@eslint/plugin-kit": {
       "version": "0.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "requires": {
@@ -7908,7 +7908,7 @@
     },
     "@humanfs/core": {
       "version": "0.19.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanfs/core/-/core-0.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "requires": {
@@ -7917,7 +7917,7 @@
     },
     "@humanfs/node": {
       "version": "0.16.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanfs/node/-/node-0.16.8.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "requires": {
@@ -7928,25 +7928,25 @@
     },
     "@humanfs/types": {
       "version": "0.15.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanfs/types/-/types-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7955,7 +7955,7 @@
     },
     "@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "requires": {
@@ -7965,17 +7965,17 @@
     },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7989,7 +7989,7 @@
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
       "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
       "dev": true,
       "requires": {
@@ -7998,7 +7998,7 @@
       "dependencies": {
         "eslint-scope": {
           "version": "5.1.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
           "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
           "dev": true,
           "requires": {
@@ -8008,7 +8008,7 @@
         },
         "estraverse": {
           "version": "4.3.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/estraverse/-/estraverse-4.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         }
@@ -8016,194 +8016,194 @@
     },
     "@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true
     },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
       "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-android-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
       "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
       "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
       "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
       "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
       "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
       "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
       "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
       "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
       "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
       "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
       "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
       "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
       "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
       "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
       "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "dev": true,
       "optional": true
     },
     "@rtsao/scc": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@rtsao/scc/-/scc-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
     "@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "requires": {
@@ -8216,7 +8216,7 @@
     },
     "@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "requires": {
@@ -8225,7 +8225,7 @@
     },
     "@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "requires": {
@@ -8235,7 +8235,7 @@
     },
     "@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "requires": {
@@ -8249,7 +8249,7 @@
     },
     "@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/estree/-/estree-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true
     },
@@ -8267,13 +8267,13 @@
     },
     "@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
@@ -8289,7 +8289,7 @@
     },
     "@types/react": {
       "version": "16.14.70",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/react/-/react-16.14.70.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.70.tgz",
       "integrity": "sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==",
       "requires": {
         "@types/prop-types": "*",
@@ -8299,14 +8299,14 @@
       "dependencies": {
         "csstype": {
           "version": "3.2.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/csstype/-/csstype-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
           "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
         }
       }
     },
     "@types/react-dom": {
       "version": "16.9.25",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/react-dom/-/react-dom-16.9.25.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
       "integrity": "sha512-ZK//eAPhwft9Ul2/Zj+6O11YR6L4JX0J2sVeBC9Ft7x7HFN7xk7yUV/zDxqV6rjvqgl6r8Dq7oQImxtyf/Mzcw==",
       "requires": {}
     },
@@ -8353,7 +8353,7 @@
     },
     "@types/scheduler": {
       "version": "0.16.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "@uifabric/foundation": {
@@ -8433,7 +8433,7 @@
     },
     "@vitejs/plugin-react": {
       "version": "4.7.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "requires": {
@@ -8447,7 +8447,7 @@
       "dependencies": {
         "react-refresh": {
           "version": "0.17.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-refresh/-/react-refresh-0.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
           "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
           "dev": true
         }
@@ -8455,20 +8455,20 @@
     },
     "acorn": {
       "version": "8.17.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/acorn/-/acorn-8.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/agent-base/-/agent-base-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
         "debug": "4"
@@ -8476,7 +8476,7 @@
     },
     "ajv": {
       "version": "6.15.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ajv/-/ajv-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "requires": {
@@ -8488,7 +8488,7 @@
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
@@ -8497,19 +8497,19 @@
     },
     "argparse": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
     "aria-query": {
       "version": "5.3.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/aria-query/-/aria-query-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true
     },
     "array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "requires": {
@@ -8519,7 +8519,7 @@
     },
     "array-includes": {
       "version": "3.1.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array-includes/-/array-includes-3.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
       "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
       "requires": {
@@ -8535,7 +8535,7 @@
     },
     "array.prototype.findlast": {
       "version": "1.2.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "requires": {
@@ -8549,7 +8549,7 @@
     },
     "array.prototype.findlastindex": {
       "version": "1.2.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
       "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "requires": {
@@ -8564,7 +8564,7 @@
     },
     "array.prototype.flat": {
       "version": "1.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
       "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "requires": {
@@ -8576,7 +8576,7 @@
     },
     "array.prototype.flatmap": {
       "version": "1.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
       "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "requires": {
@@ -8588,7 +8588,7 @@
     },
     "array.prototype.tosorted": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "requires": {
@@ -8601,7 +8601,7 @@
     },
     "arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "requires": {
@@ -8616,24 +8616,24 @@
     },
     "ast-types-flow": {
       "version": "0.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
     "async-function": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/async-function/-/async-function-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "requires": {
@@ -8642,13 +8642,13 @@
     },
     "axe-core": {
       "version": "4.12.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/axe-core/-/axe-core-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
       "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true
     },
     "axios": {
       "version": "1.18.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/axios/-/axios-1.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "requires": {
         "follow-redirects": "^1.16.0",
@@ -8659,7 +8659,7 @@
     },
     "axobject-query": {
       "version": "4.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/axobject-query/-/axobject-query-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true
     },
@@ -8704,7 +8704,7 @@
         },
         "yaml": {
           "version": "1.10.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/yaml/-/yaml-1.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
           "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="
         }
       }
@@ -8727,7 +8727,7 @@
     },
     "baseline-browser-mapping": {
       "version": "2.10.42",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true
     },
@@ -8739,7 +8739,7 @@
     },
     "brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
@@ -8749,7 +8749,7 @@
     },
     "browserslist": {
       "version": "4.28.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/browserslist/-/browserslist-4.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
       "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "requires": {
@@ -8762,7 +8762,7 @@
     },
     "call-bind": {
       "version": "1.0.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/call-bind/-/call-bind-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "requires": {
@@ -8774,7 +8774,7 @@
     },
     "call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "requires": {
         "es-errors": "^1.3.0",
@@ -8783,7 +8783,7 @@
     },
     "call-bound": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "requires": {
@@ -8798,13 +8798,13 @@
     },
     "caniuse-lite": {
       "version": "1.0.30001803",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
       "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true
     },
     "chalk": {
       "version": "4.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
@@ -8819,7 +8819,7 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
@@ -8828,13 +8828,13 @@
     },
     "color-name": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -8856,7 +8856,7 @@
     },
     "core-js": {
       "version": "3.49.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/core-js/-/core-js-3.49.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
       "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="
     },
     "cron-validator": {
@@ -8871,7 +8871,7 @@
     },
     "cross-env": {
       "version": "7.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cross-env/-/cross-env-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
       "requires": {
@@ -8880,7 +8880,7 @@
     },
     "cross-fetch": {
       "version": "4.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "requires": {
         "node-fetch": "^2.7.0"
@@ -8888,7 +8888,7 @@
     },
     "cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
@@ -8899,7 +8899,7 @@
     },
     "crypto-js": {
       "version": "4.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/crypto-js/-/crypto-js-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "csstype": {
@@ -8909,13 +8909,13 @@
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
     "data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "requires": {
@@ -8926,7 +8926,7 @@
     },
     "data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "requires": {
@@ -8937,7 +8937,7 @@
     },
     "data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "requires": {
@@ -8953,7 +8953,7 @@
     },
     "debug": {
       "version": "4.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
         "ms": "^2.1.3"
@@ -8961,20 +8961,20 @@
       "dependencies": {
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
     "deep-is": {
       "version": "0.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/deep-is/-/deep-is-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/define-data-property/-/define-data-property-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "requires": {
@@ -8985,7 +8985,7 @@
     },
     "define-properties": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/define-properties/-/define-properties-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "requires": {
@@ -8996,7 +8996,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "dom-helpers": {
@@ -9017,7 +9017,7 @@
     },
     "dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "requires": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -9027,7 +9027,7 @@
     },
     "electron-to-chromium": {
       "version": "1.5.389",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
       "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true
     },
@@ -9041,7 +9041,7 @@
     },
     "es-abstract": {
       "version": "1.24.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-abstract/-/es-abstract-1.24.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
       "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "requires": {
@@ -9103,7 +9103,7 @@
     },
     "es-abstract-get": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
       "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
       "dev": true,
       "requires": {
@@ -9115,17 +9115,17 @@
     },
     "es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
     "es-errors": {
       "version": "1.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-iterator-helpers": {
       "version": "1.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
       "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
       "dev": true,
       "requires": {
@@ -9149,7 +9149,7 @@
     },
     "es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "requires": {
         "es-errors": "^1.3.0"
@@ -9157,7 +9157,7 @@
     },
     "es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "requires": {
         "es-errors": "^1.3.0",
@@ -9168,7 +9168,7 @@
     },
     "es-shim-unscopables": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
       "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "requires": {
@@ -9177,7 +9177,7 @@
     },
     "es-to-primitive": {
       "version": "1.3.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
       "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "requires": {
@@ -9191,7 +9191,7 @@
     },
     "esbuild": {
       "version": "0.25.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/esbuild/-/esbuild-0.25.12.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "requires": {
@@ -9225,7 +9225,7 @@
     },
     "escalade": {
       "version": "3.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
     },
@@ -9236,7 +9236,7 @@
     },
     "eslint": {
       "version": "9.39.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint/-/eslint-9.39.4.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "requires": {
@@ -9278,13 +9278,13 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
         "find-up": {
           "version": "5.0.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/find-up/-/find-up-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
           "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "dev": true,
           "requires": {
@@ -9294,7 +9294,7 @@
         },
         "locate-path": {
           "version": "6.0.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/locate-path/-/locate-path-6.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
           "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
@@ -9303,7 +9303,7 @@
         },
         "p-limit": {
           "version": "3.1.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/p-limit/-/p-limit-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
           "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
@@ -9312,7 +9312,7 @@
         },
         "p-locate": {
           "version": "5.0.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/p-locate/-/p-locate-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
           "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
           "dev": true,
           "requires": {
@@ -9323,7 +9323,7 @@
     },
     "eslint-import-resolver-node": {
       "version": "0.3.10",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
       "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "dev": true,
       "requires": {
@@ -9334,7 +9334,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
@@ -9343,13 +9343,13 @@
         },
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "resolve": {
           "version": "2.0.0-next.7",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/resolve/-/resolve-2.0.0-next.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
           "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
           "dev": true,
           "requires": {
@@ -9365,7 +9365,7 @@
     },
     "eslint-module-utils": {
       "version": "2.14.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
       "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "requires": {
@@ -9374,7 +9374,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
@@ -9383,7 +9383,7 @@
         },
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
@@ -9391,7 +9391,7 @@
     },
     "eslint-plugin-import": {
       "version": "2.32.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "requires": {
@@ -9418,7 +9418,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
@@ -9427,7 +9427,7 @@
         },
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/doctrine/-/doctrine-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
@@ -9436,13 +9436,13 @@
         },
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ms/-/ms-2.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -9450,7 +9450,7 @@
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "requires": {
@@ -9473,7 +9473,7 @@
       "dependencies": {
         "emoji-regex": {
           "version": "9.2.2",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
           "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
           "dev": true
         }
@@ -9481,7 +9481,7 @@
     },
     "eslint-plugin-react": {
       "version": "7.37.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "requires": {
@@ -9516,7 +9516,7 @@
         },
         "resolve": {
           "version": "2.0.0-next.7",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/resolve/-/resolve-2.0.0-next.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
           "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
           "dev": true,
           "requires": {
@@ -9530,7 +9530,7 @@
         },
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -9538,7 +9538,7 @@
     },
     "eslint-scope": {
       "version": "8.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "requires": {
@@ -9548,13 +9548,13 @@
     },
     "eslint-visitor-keys": {
       "version": "4.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true
     },
     "espree": {
       "version": "10.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/espree/-/espree-10.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "requires": {
@@ -9565,7 +9565,7 @@
     },
     "esquery": {
       "version": "1.7.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/esquery/-/esquery-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "requires": {
@@ -9574,7 +9574,7 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
@@ -9583,7 +9583,7 @@
     },
     "estraverse": {
       "version": "5.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/estraverse/-/estraverse-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
@@ -9607,20 +9607,20 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fdir": {
       "version": "6.5.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "requires": {}
     },
     "file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "requires": {
@@ -9639,7 +9639,7 @@
     },
     "flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/flat-cache/-/flat-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "requires": {
@@ -9649,18 +9649,18 @@
     },
     "flatted": {
       "version": "3.4.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/flatted/-/flatted-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "follow-redirects": {
       "version": "1.16.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "for-each": {
       "version": "0.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/for-each/-/for-each-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "requires": {
@@ -9669,7 +9669,7 @@
     },
     "form-data": {
       "version": "4.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/form-data/-/form-data-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "requires": {
         "asynckit": "^0.4.0",
@@ -9681,19 +9681,19 @@
     },
     "fsevents": {
       "version": "2.3.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
     },
     "function-bind": {
       "version": "1.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
       "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "requires": {
@@ -9710,13 +9710,13 @@
     },
     "functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
     "generator-function": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/generator-function/-/generator-function-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true
     },
@@ -9728,7 +9728,7 @@
     },
     "get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9745,7 +9745,7 @@
     },
     "get-proto": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "requires": {
         "dunder-proto": "^1.0.1",
@@ -9754,7 +9754,7 @@
     },
     "get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "requires": {
@@ -9765,7 +9765,7 @@
     },
     "glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/glob-parent/-/glob-parent-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "requires": {
@@ -9774,13 +9774,13 @@
     },
     "globals": {
       "version": "14.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/globals/-/globals-14.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true
     },
     "globalthis": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/globalthis/-/globalthis-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "requires": {
@@ -9790,24 +9790,24 @@
     },
     "gopd": {
       "version": "1.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-bigints/-/has-bigints-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "requires": {
@@ -9816,7 +9816,7 @@
     },
     "has-proto": {
       "version": "1.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-proto/-/has-proto-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "requires": {
@@ -9825,12 +9825,12 @@
     },
     "has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "requires": {
         "has-symbols": "^1.0.3"
@@ -9838,7 +9838,7 @@
     },
     "hasown": {
       "version": "2.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "requires": {
         "function-bind": "^1.1.2"
@@ -9867,7 +9867,7 @@
     },
     "html-parse-stringify": {
       "version": "3.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "requires": {
         "void-elements": "3.1.0"
@@ -9875,7 +9875,7 @@
     },
     "https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "requires": {
         "agent-base": "6",
@@ -9900,7 +9900,7 @@
     },
     "i18next-http-backend": {
       "version": "3.0.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
       "integrity": "sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==",
       "requires": {
         "cross-fetch": "4.1.0"
@@ -9908,7 +9908,7 @@
     },
     "ignore": {
       "version": "5.3.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/ignore/-/ignore-5.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true
     },
@@ -9923,13 +9923,13 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/internal-slot/-/internal-slot-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "requires": {
@@ -9940,7 +9940,7 @@
     },
     "is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "requires": {
@@ -9956,7 +9956,7 @@
     },
     "is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-async-function/-/is-async-function-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "requires": {
@@ -9969,7 +9969,7 @@
     },
     "is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-bigint/-/is-bigint-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "requires": {
@@ -9978,7 +9978,7 @@
     },
     "is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "requires": {
@@ -9988,13 +9988,13 @@
     },
     "is-callable": {
       "version": "1.2.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-callable/-/is-callable-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true
     },
     "is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-core-module/-/is-core-module-2.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "requires": {
         "hasown": "^2.0.3"
@@ -10002,7 +10002,7 @@
     },
     "is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-data-view/-/is-data-view-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "requires": {
@@ -10013,7 +10013,7 @@
     },
     "is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-date-object/-/is-date-object-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "requires": {
@@ -10023,7 +10023,7 @@
     },
     "is-document.all": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-document.all/-/is-document.all-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
       "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
       "dev": true,
       "requires": {
@@ -10038,7 +10038,7 @@
     },
     "is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "requires": {
@@ -10047,7 +10047,7 @@
     },
     "is-generator-function": {
       "version": "1.1.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "requires": {
@@ -10060,7 +10060,7 @@
     },
     "is-glob": {
       "version": "4.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
@@ -10069,19 +10069,19 @@
     },
     "is-map": {
       "version": "2.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-map/-/is-map-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true
     },
     "is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-number-object/-/is-number-object-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "requires": {
@@ -10091,7 +10091,7 @@
     },
     "is-regex": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-regex/-/is-regex-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "requires": {
@@ -10103,13 +10103,13 @@
     },
     "is-set": {
       "version": "2.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-set/-/is-set-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true
     },
     "is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "requires": {
@@ -10118,7 +10118,7 @@
     },
     "is-string": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-string/-/is-string-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "requires": {
@@ -10128,7 +10128,7 @@
     },
     "is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-symbol/-/is-symbol-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "requires": {
@@ -10139,7 +10139,7 @@
     },
     "is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "requires": {
@@ -10148,13 +10148,13 @@
     },
     "is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true
     },
     "is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-weakref/-/is-weakref-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "requires": {
@@ -10163,7 +10163,7 @@
     },
     "is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/is-weakset/-/is-weakset-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "requires": {
@@ -10178,13 +10178,13 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "iterator.prototype": {
       "version": "1.1.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "requires": {
@@ -10208,7 +10208,7 @@
     },
     "js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/js-yaml/-/js-yaml-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "requires": {
@@ -10217,12 +10217,12 @@
     },
     "jsesc": {
       "version": "3.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="
     },
     "json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json-buffer/-/json-buffer-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
@@ -10233,25 +10233,25 @@
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
       "version": "2.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsx-ast-utils": {
       "version": "3.3.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "requires": {
@@ -10263,7 +10263,7 @@
     },
     "keyv": {
       "version": "4.5.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/keyv/-/keyv-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "requires": {
@@ -10272,13 +10272,13 @@
     },
     "language-subtag-registry": {
       "version": "0.3.23",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
       "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true
     },
     "language-tags": {
       "version": "1.0.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/language-tags/-/language-tags-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "requires": {
@@ -10287,7 +10287,7 @@
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
@@ -10302,7 +10302,7 @@
     },
     "lodash": {
       "version": "4.18.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/lodash/-/lodash-4.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.isfunction": {
@@ -10317,7 +10317,7 @@
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
@@ -10336,7 +10336,7 @@
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
@@ -10345,7 +10345,7 @@
     },
     "math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "memoize-one": {
@@ -10355,12 +10355,12 @@
     },
     "mime-db": {
       "version": "1.52.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
         "mime-db": "1.52.0"
@@ -10377,7 +10377,7 @@
     },
     "minimatch": {
       "version": "3.1.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
@@ -10386,7 +10386,7 @@
     },
     "minimist": {
       "version": "1.2.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
@@ -10403,18 +10403,18 @@
     },
     "nanoid": {
       "version": "3.3.15",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/nanoid/-/nanoid-3.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node-exports-info": {
       "version": "1.6.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
       "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
       "dev": true,
       "requires": {
@@ -10426,7 +10426,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/semver/-/semver-6.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
@@ -10434,7 +10434,7 @@
     },
     "node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -10442,7 +10442,7 @@
     },
     "node-releases": {
       "version": "2.0.50",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/node-releases/-/node-releases-2.0.50.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true
     },
@@ -10453,7 +10453,7 @@
     },
     "object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true
     },
@@ -10465,7 +10465,7 @@
     },
     "object.assign": {
       "version": "4.1.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.assign/-/object.assign-4.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "requires": {
@@ -10479,7 +10479,7 @@
     },
     "object.entries": {
       "version": "1.1.9",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.entries/-/object.entries-1.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "requires": {
@@ -10491,7 +10491,7 @@
     },
     "object.fromentries": {
       "version": "2.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
       "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "requires": {
@@ -10503,7 +10503,7 @@
     },
     "object.groupby": {
       "version": "1.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.groupby/-/object.groupby-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
       "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
       "requires": {
@@ -10514,7 +10514,7 @@
     },
     "object.values": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/object.values/-/object.values-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
       "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "requires": {
@@ -10546,7 +10546,7 @@
     },
     "oidc-client": {
       "version": "1.11.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/oidc-client/-/oidc-client-1.11.5.tgz",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
       "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
       "requires": {
         "acorn": "^7.4.1",
@@ -10558,14 +10558,14 @@
       "dependencies": {
         "acorn": {
           "version": "7.4.1",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/acorn/-/acorn-7.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
         }
       }
     },
     "optionator": {
       "version": "0.9.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/optionator/-/optionator-0.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "requires": {
@@ -10579,7 +10579,7 @@
     },
     "own-keys": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/own-keys/-/own-keys-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "requires": {
@@ -10598,7 +10598,7 @@
     },
     "parse-json": {
       "version": "5.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -10609,24 +10609,24 @@
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "1.9.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
       "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "requires": {
         "isarray": "0.0.1"
@@ -10639,12 +10639,12 @@
     },
     "picocolors": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "4.0.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/picomatch/-/picomatch-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true
     },
@@ -10655,13 +10655,13 @@
     },
     "possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true
     },
     "postcss": {
       "version": "8.5.16",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/postcss/-/postcss-8.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "requires": {
@@ -10672,13 +10672,13 @@
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "prop-types": {
       "version": "15.8.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/prop-types/-/prop-types-15.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "requires": {
         "loose-envify": "^1.4.0",
@@ -10688,12 +10688,12 @@
     },
     "proxy-from-env": {
       "version": "2.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
     "punycode": {
       "version": "2.3.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/punycode/-/punycode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
@@ -10709,7 +10709,7 @@
     },
     "react-checkbox-tree": {
       "version": "1.8.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-checkbox-tree/-/react-checkbox-tree-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.8.0.tgz",
       "integrity": "sha512-ufC4aorihOvjLpvY1beab2hjVLGZbDTFRzw62foG0+th+KX7e/sdmWu/nD1ZS/U5Yr0rWGwedGH5GOtR0IkUXw==",
       "requires": {
         "classnames": "^2.2.5",
@@ -10731,7 +10731,7 @@
     },
     "react-i18next": {
       "version": "11.18.6",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-i18next/-/react-i18next-11.18.6.tgz",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
       "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
       "requires": {
         "@babel/runtime": "^7.14.5",
@@ -10868,7 +10868,7 @@
     },
     "reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "requires": {
@@ -10884,7 +10884,7 @@
     },
     "regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "requires": {
@@ -10898,7 +10898,7 @@
     },
     "resolve": {
       "version": "1.22.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/resolve/-/resolve-1.22.12.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "requires": {
         "es-errors": "^1.3.0",
@@ -10919,7 +10919,7 @@
     },
     "safe-array-concat": {
       "version": "1.1.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
       "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "requires": {
@@ -10932,7 +10932,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.5",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
           "dev": true
         }
@@ -10945,7 +10945,7 @@
     },
     "safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "requires": {
@@ -10955,7 +10955,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.5",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
           "dev": true
         }
@@ -10963,7 +10963,7 @@
     },
     "safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "requires": {
@@ -10983,12 +10983,12 @@
     },
     "serialize-javascript": {
       "version": "7.0.7",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
       "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g=="
     },
     "set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-function-length/-/set-function-length-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "requires": {
@@ -11002,7 +11002,7 @@
     },
     "set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-function-name/-/set-function-name-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "requires": {
@@ -11014,7 +11014,7 @@
     },
     "set-proto": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-proto/-/set-proto-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "requires": {
@@ -11025,7 +11025,7 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
@@ -11034,13 +11034,13 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "side-channel": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "requires": {
@@ -11053,7 +11053,7 @@
     },
     "side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "requires": {
@@ -11063,7 +11063,7 @@
     },
     "side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "requires": {
@@ -11075,7 +11075,7 @@
     },
     "side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "requires": {
@@ -11093,13 +11093,13 @@
     },
     "source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
     "stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "requires": {
@@ -11109,7 +11109,7 @@
     },
     "string.prototype.includes": {
       "version": "2.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "requires": {
@@ -11120,7 +11120,7 @@
     },
     "string.prototype.matchall": {
       "version": "4.0.12",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "requires": {
@@ -11141,7 +11141,7 @@
     },
     "string.prototype.repeat": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "requires": {
@@ -11151,7 +11151,7 @@
     },
     "string.prototype.trim": {
       "version": "1.2.11",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
       "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "requires": {
@@ -11167,7 +11167,7 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.10",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
       "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "requires": {
@@ -11179,7 +11179,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "requires": {
@@ -11190,19 +11190,19 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
       "version": "7.2.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
@@ -11211,7 +11211,7 @@
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "tiny-invariant": {
@@ -11226,7 +11226,7 @@
     },
     "tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "requires": {
@@ -11236,12 +11236,12 @@
     },
     "tr46": {
       "version": "0.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tsconfig-paths": {
       "version": "3.15.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "requires": {
@@ -11253,7 +11253,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.2",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/json5/-/json5-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
           "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
@@ -11269,7 +11269,7 @@
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
@@ -11278,7 +11278,7 @@
     },
     "typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "requires": {
@@ -11289,7 +11289,7 @@
     },
     "typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "requires": {
@@ -11302,7 +11302,7 @@
     },
     "typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "requires": {
@@ -11317,7 +11317,7 @@
     },
     "typed-array-length": {
       "version": "1.0.8",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
       "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "requires": {
@@ -11337,7 +11337,7 @@
     },
     "unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "requires": {
@@ -11349,7 +11349,7 @@
     },
     "update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "requires": {
@@ -11359,7 +11359,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
@@ -11373,7 +11373,7 @@
     },
     "vite": {
       "version": "6.4.3",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/vite/-/vite-6.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "requires": {
@@ -11388,7 +11388,7 @@
       "dependencies": {
         "rollup": {
           "version": "4.62.2",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/rollup/-/rollup-4.62.2.tgz",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
           "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
           "dev": true,
           "requires": {
@@ -11425,17 +11425,17 @@
     },
     "void-elements": {
       "version": "3.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/void-elements/-/void-elements-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
     },
     "webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
@@ -11444,7 +11444,7 @@
     },
     "which": {
       "version": "2.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
@@ -11453,7 +11453,7 @@
     },
     "which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "requires": {
@@ -11466,7 +11466,7 @@
     },
     "which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "requires": {
@@ -11487,7 +11487,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.5",
-          "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/isarray/-/isarray-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
           "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
           "dev": true
         }
@@ -11495,7 +11495,7 @@
     },
     "which-collection": {
       "version": "1.0.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-collection/-/which-collection-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "requires": {
@@ -11507,7 +11507,7 @@
     },
     "which-typed-array": {
       "version": "1.1.22",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
       "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "requires": {
@@ -11522,19 +11522,19 @@
     },
     "word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/word-wrap/-/word-wrap-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }


### PR DESCRIPTION
## Problem

`ClientApp/package-lock.json` was generated inside Autodesk's network, so 782 of its `resolved` URLs point at the internal Artifactory mirror (`npm.autodesk.com/artifactory/api/npm/npm-remote/...`). That hostname doesn't resolve on the public internet, so `npm install` fails for anyone outside Autodesk:

```
npm error network request to https://npm.autodesk.com/artifactory/api/npm/npm-remote/which-typed-array/-/which-typed-array-1.1.22.tgz failed, reason: getaddrinfo ENOTFOUND npm.autodesk.com
```

## Fix

Mechanical rewrite of the Artifactory prefix to `https://registry.npmjs.org/` (the mirror is a 1:1 proxy of the public registry). Package versions and `integrity` hashes are unchanged, so npm still verifies every tarball against the same SHA-512 hashes.

Verified with a clean `npm install` (456 packages added, 0 vulnerabilities) and by running the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
