### PR TITLE
fix: remove hardcoded DB credentials from DbContext factories

### DIFF
--- a/Context/PostgreSQLRevitIfcContext.cs
+++ b/Context/PostgreSQLRevitIfcContext.cs
@@ -40,16 +40,6 @@ namespace RevitToIfcScheduler.Context
             : base(options)
         {
         }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            if (!optionsBuilder.IsConfigured)
-            {
-                optionsBuilder.UseNpgsql(
-                    "Host=localhost;Database=RevitIFCScheduler;Username=postgres;Password=postgres",
-                    b => b.MigrationsAssembly("RevitToIfcScheduler"));
-            }
-        }
     }
 
     public class PostgreSQLRevitIfcContextFactory : IDesignTimeDbContextFactory<PostgreSQLRevitIfcContext>

--- a/Context/PostgreSQLRevitIfcContext.cs
+++ b/Context/PostgreSQLRevitIfcContext.cs
@@ -16,8 +16,10 @@
 // UNINTERRUPTED OR ERROR FREE.
 /////////////////////////////////////////////////////////////////////
 
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
 
 namespace RevitToIfcScheduler.Context
 {
@@ -46,9 +48,23 @@ namespace RevitToIfcScheduler.Context
     {
         public PostgreSQLRevitIfcContext CreateDbContext(string[] args)
         {
+            var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile($"appsettings.{env}.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var connectionString = config.GetConnectionString("SqlDB");
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new InvalidOperationException(
+                    "ConnectionStrings:SqlDB is not set. Add it to appsettings.Development.json or set it as an environment variable.");
+            }
+
             var optionsBuilder = new DbContextOptionsBuilder<RevitIfcContext>();
             optionsBuilder.UseNpgsql(
-                "Host=localhost;Database=RevitIFCScheduler;Username=postgres;Password=postgres",
+                connectionString,
                 b => b.MigrationsAssembly("RevitToIfcScheduler"));
 
             return new PostgreSQLRevitIfcContext(optionsBuilder.Options);

--- a/Context/RevitIfcContext.cs
+++ b/Context/RevitIfcContext.cs
@@ -16,9 +16,11 @@
 // UNINTERRUPTED OR ERROR FREE.
 /////////////////////////////////////////////////////////////////////
 
+using System;
 using RevitToIfcScheduler.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
 
 namespace RevitToIfcScheduler.Context
 {
@@ -26,9 +28,23 @@ namespace RevitToIfcScheduler.Context
     {
         public RevitIfcContext CreateDbContext(string[] args)
         {
+            var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile($"appsettings.{env}.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var connectionString = config.GetConnectionString("SqlDB");
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new InvalidOperationException(
+                    "ConnectionStrings:SqlDB is not set. Add it to appsettings.Development.json or set it as an environment variable.");
+            }
+
             var optionsBuilder = new DbContextOptionsBuilder<RevitIfcContext>();
             optionsBuilder.UseSqlServer(
-                "Server=(localdb)\\MSSQLLocalDB;Database=RevitIFCScheduler;Trusted_Connection=True;",
+                connectionString,
                 b => b.MigrationsAssembly("RevitToIfcScheduler"));
 
             return new RevitIfcContext(optionsBuilder.Options);


### PR DESCRIPTION
This pull request removes hardcoded database credentials from the EF Core design-time context factories.

- Removes the hardcoded PostgreSQL connection string (Username=postgres;Password=postgres) from PostgreSQLRevitIfcContext's OnConfiguring fallback.
- Removes the hardcoded LocalDB connection string from RevitIfcContextFactory.
- Both factories now read ConnectionStrings:SqlDB via ConfigurationBuilder (appsettings.json, environment-specific settings, and environment variables), and throw a clear error if it isn't configured.