### PR TITLE
fix: restore public npm registry URLs in package-lock.json

### DIFF
--- a/ClientApp/package-lock.json
+++ b/ClientApp/package-lock.json
@@ -2862,7 +2862,7 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/cookie/-/cookie-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
@@ -5555,7 +5555,7 @@
     },
     "node_modules/react-router": {
       "version": "7.18.1",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/react-router/-/react-router-7.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
       "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
@@ -5807,7 +5807,7 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
-      "resolved": "https://npm.autodesk.com/artifactory/api/npm/npm-remote/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },


### PR DESCRIPTION
Rewrite the three remaining npm 'resolved' URLs (cookie, react-router, set-cookie-parser) to registry.npmjs.org and prune an extraneous yaml entry recorded from local node_modules state.